### PR TITLE
Add a command to declare moderator roles

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from discord.ext import commands
+import discord
 import constants
 import repository
 
@@ -27,14 +28,30 @@ async def prefix(ctx, new_prefix):
 
     await ctx.send('Prefix set to: "{}"'.format(new_prefix))
 
-@bot.command
-async def modrole(ctx, action, role):
+@bot.command()
+async def modrole(ctx: commands.Context, action: str, role: discord.Role):
     """
     Add or remove moderator roles.
     action: add/remove
     """
-    #TODO: Implement!
-    pass
+
+    action = action.lower()
+
+    if action == 'add':
+        result = repository.add_mod_role(ctx.guild.id, role.id)
+
+        if result:
+            await ctx.send(f'Added moderator role: {role.name}')
+        else:
+            await ctx.send(f'{role.name} is already moderator!')
+
+    elif action == 'remove':
+        result = repository.delete_mod_role(ctx.guild.id, role.id)
+
+        if result:
+            await ctx.send(f'Removed moderator role: {role.name}')
+        else:
+            await ctx.send(f'{role.name} is not a moderator!')
 
 repository.init()
 bot.run(repository.get_bot_token(True))

--- a/repository.py
+++ b/repository.py
@@ -7,7 +7,7 @@ Repository for storage using SQL.
 This is basically a bridge between sqlhelper.py and main.py
 """
 
-init = sqlhelper.init_prefix_table
+init = sqlhelper.create_tables
 
 def get_prefix(guild_id):
     prefix = sqlhelper.get_guild_prefix(guild_id)
@@ -32,3 +32,33 @@ def get_bot_token(debug=False):
             return dat['debug_token']
         else:
             return dat['production_token']
+
+def add_mod_role(guild_id, role_id):
+    """
+    Adds the moderator role for the gluid to the db.
+    Returns False if the role was already present, True otherwise.
+    """
+
+    entries = sqlhelper.get_moderator_roles(guild_id)
+    if (role_id,) in entries:
+        return False
+
+    sqlhelper.add_moderator_role(guild_id, role_id)
+    return True
+
+def delete_mod_role(guild_id, to_delete):
+    """
+    Removes the moderator role for the gluid to from the db.
+    Returns False if the role was not present, True otherwise.
+    """
+
+    entries = sqlhelper.get_moderator_roles_with_index(guild_id)
+
+    for index, role_id in entries:
+        if role_id != to_delete:
+            continue
+
+        sqlhelper.delete_moderator_role(index)
+        return True
+
+    return False

--- a/sqlhelper.py
+++ b/sqlhelper.py
@@ -16,6 +16,32 @@ sql_update_prefix_for_guild = """
     INSERT OR REPLACE INTO prefixes(guild_id, prefix)
     VALUES (?, ?)"""
 
+sql_create_modrole_table = """
+    CREATE TABLE IF NOT EXISTS modroles (
+        id INTEGER PRIMARY KEY,
+        guild_id INTEGER,
+        role_id INTEGER
+    );"""
+
+sql_get_modroles = """
+    SELECT role_id
+    FROM modroles
+    WHERE guild_id = ?"""
+
+#Note: 'index' refers to table's PRIMARY KEY
+sql_get_modroles_and_index = """ 
+    SELECT id, role_id
+    FROM modroles
+    WHERE guild_id = ?"""
+
+sql_insert_modrole = """
+    INSERT INTO modroles(guild_id, role_id)
+    VALUES (?, ?)"""
+
+sql_delete_modrole = """
+    DELETE FROM modroles
+    WHERE id = ?"""
+
 def connect_db():
     try:
         conn = sqlite3.connect('database.sql')
@@ -27,11 +53,12 @@ def connect_db():
     except sqlite3.Error as error:
         sys.stderr.write(error)
 
-def init_prefix_table():
+def create_tables():
     try:
         conn = connect_db()
         cursor = conn.cursor()
         cursor.execute(sql_create_prefix_table)
+        cursor.execute(sql_create_modrole_table)
     except sqlite3.Error as e:
         sys.stderr.write(e)
     finally:
@@ -65,3 +92,47 @@ def update_guild_prefix(guild_id, new_prefix):
         sys.stderr.write(e)
     finally:
         if conn: conn.close()
+
+def add_moderator_role(guild_id, role_id):
+    try:
+        conn = connect_db()
+        cursor = conn.cursor()
+        cursor.execute(sql_insert_modrole, (guild_id, role_id))
+        conn.commit()
+    except sqlite3.Error as e:
+        sys.stderr.write(e)
+    finally:
+        if conn: conn.close()
+
+def delete_moderator_role(entry_key):
+    try:
+        conn = connect_db()
+        cursor = conn.cursor()
+        cursor.execute(sql_delete_modrole, (entry_key,))
+    except sqlite3.Error as e:
+        sys.stderr.write(e)
+    finally:
+        if conn: conn.close()
+
+def get_moderator_roles(guild_id):
+    try:
+        conn = connect_db()
+        cursor = conn.cursor()
+        cursor.execute(sql_get_modroles, (guild_id,))
+        return cursor.fetchall()
+    except sqlite3.Error as e:
+        sys.stderr.write(e)
+    finally:
+        if conn: conn.close()
+
+#Index refers to the PRIMARY KEY column of the table
+def get_moderator_roles_with_index(guild_id):
+    try:
+        conn = connect_db()
+        cursor = conn.cursor()
+        cursor.execute(sql_get_modroles_and_index, (guild_id,))
+        return cursor.fetchall()
+    except sqlite3.Error as e:
+        sys.stderr.write(e)
+    finally:
+        if conn: conn.close

--- a/sqlhelper.py
+++ b/sqlhelper.py
@@ -109,6 +109,7 @@ def delete_moderator_role(entry_key):
         conn = connect_db()
         cursor = conn.cursor()
         cursor.execute(sql_delete_modrole, (entry_key,))
+        conn.commit()
     except sqlite3.Error as e:
         sys.stderr.write(e)
     finally:

--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,10 @@ class TestModRoleCommand(unittest.TestCase):
         )
 
         self.assertFalse(
+            repo.delete_mod_role(self.GUILD1, self.ROLE1)
+        )
+
+        self.assertFalse(
             repo.delete_mod_role(self.GUILD1, self.ROLE2)
         )
 
@@ -72,6 +76,16 @@ class TestModRoleCommand(unittest.TestCase):
 
         self.assertTrue(
             repo.delete_mod_role(self.GUILD2, self.ROLE1)
+        )
+
+
+        #These two stay in db
+        self.assertTrue(
+            repo.add_mod_role(self.GUILD1, self.ROLE2)
+        )
+
+        self.assertTrue(
+            repo.add_mod_role(self.GUILD2, self.ROLE2)
         )
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -12,12 +12,14 @@ respective classes.
 import unittest
 import repository as repo
 import sqlhelper as sql
+import repository as repo
 import os
 
 #Remove the comment to delete the `database.sql` file automatically.
 #This can be helpful for easing out the process.
 #DO NOT commit to git with the comment removed.
 # os.remove('database.sql')
+sql.create_tables()
 
 class TestPrefixCommand(unittest.TestCase):
     """
@@ -29,14 +31,46 @@ class TestPrefixCommand(unittest.TestCase):
         Tests the SQL functions of this command
         """
 
-        GUILD_ID = 55
-
-        sql.init_prefix_table()
-
-        self.assertEquals(repo.get_prefix(GUILD_ID), '~')
+        self.assertEquals(sql.get_guild_prefix(55), '~')
 
         sql.update_guild_prefix(55, "%")
         self.assertEquals(repo.get_prefix(GUILD_ID), '%')
+
+class TestModRoleCommand(unittest.TestCase):
+    """
+    Test cases for `modrole` command
+    """
+
+    GUILD1 = 55
+    GUILD2 = 66
+    ROLE1 = 5
+    ROLE2 = 3
+
+    def test_add_remove(self):
+
+        self.assertTrue(
+            repo.add_mod_role(self.GUILD1, self.ROLE1)
+        )
+
+        self.assertTrue(
+            repo.add_mod_role(self.GUILD2, self.ROLE1)
+        )
+
+        self.assertTrue(
+            repo.delete_mod_role(self.GUILD1, self.ROLE1)
+        )
+
+        self.assertFalse(
+            repo.delete_mod_role(self.GUILD1, self.ROLE2)
+        )
+
+        self.assertFalse(
+            repo.delete_mod_role(self.GUILD2, self.ROLE2)
+        )
+
+        self.assertTrue(
+            repo.delete_mod_role(self.GUILD2, self.ROLE1)
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -30,11 +30,10 @@ class TestPrefixCommand(unittest.TestCase):
         """
         Tests the SQL functions of this command
         """
-        
+
         GUILD_ID = 55
 
         self.assertEquals(repo.get_prefix(GUILD_ID), '~')
-        self.assertEquals(sql.get_guild_prefix(55), '~')
 
         sql.update_guild_prefix(55, "%")
         self.assertEquals(repo.get_prefix(GUILD_ID), '%')

--- a/tests.py
+++ b/tests.py
@@ -30,7 +30,10 @@ class TestPrefixCommand(unittest.TestCase):
         """
         Tests the SQL functions of this command
         """
+        
+        GUILD_ID = 55
 
+        self.assertEquals(repo.get_prefix(GUILD_ID), '~')
         self.assertEquals(sql.get_guild_prefix(55), '~')
 
         sql.update_guild_prefix(55, "%")


### PR DESCRIPTION
`modrole` command can be used to add or remove moderator roles. Roles declared mods using this command get some additional permissions.