### PR TITLE
Add birthday greetings and calendar commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ I have planned to add these features to the bot, you're welcome to edit this fil
 
 - [x] Command to change the bot prefix,
 - [x] Command to add moderator roles, which have access to some special commands.
+- [x] Birthday greetings! Also draws a nice looking calendar in the specified channel.
 - [ ] Command to schedule and host 'Question Of The Day' event.
 
 ## Contributing

--- a/equibot/app.py
+++ b/equibot/app.py
@@ -8,7 +8,7 @@ from . import commandcogs
 
 bot = commands.Bot(
     command_prefix = lambda bot, message:
-        repo.get_prefix(message.channel.guild.id),
+        "t!",
 
     description="""A nice general purpose bot for your server"""
 )

--- a/equibot/app.py
+++ b/equibot/app.py
@@ -25,6 +25,10 @@ async def on_ready():
     bot.add_cog(commandcogs.General(repo))
     bot.add_cog(commandcogs.Moderation(repo))
 
+    birthdayscog = commandcogs.Birthdays(repo)
+    bot.add_cog(birthdayscog)
+    bot.loop.create_task(birthdayscog.birthday_ticker(bot))
+
 @bot.event
 async def on_message(message: discord.Message):
 

--- a/equibot/commandcogs/__init__.py
+++ b/equibot/commandcogs/__init__.py
@@ -1,3 +1,4 @@
 from .general import General
 from .moderation import Moderation
 from .birthdays import Birthdays
+from .calendarbuider import CalendarBuilder

--- a/equibot/commandcogs/__init__.py
+++ b/equibot/commandcogs/__init__.py
@@ -1,2 +1,3 @@
 from .general import General
 from .moderation import Moderation
+from .birthdays import Birthdays

--- a/equibot/commandcogs/birthdays.py
+++ b/equibot/commandcogs/birthdays.py
@@ -1,0 +1,131 @@
+from discord.ext import commands
+import discord
+import asyncio
+
+from .. import util
+from .. import repository
+
+class Birthdays(commands.Cog):
+
+    def __init__(self, repo: repository.Repository):
+        self.repo = repo
+
+    @commands.command()
+    async def birthday(self, ctx: commands.Context, *args):
+        """
+        Add your name to birthday calendar!
+        """
+
+        if len(args) != 2:
+            await ctx.send(
+                "Invalid arguments ;-;\n" +
+                "**Usage: " +
+                f"{self.repo.get_prefix(ctx.guild.id)}**" +
+                "birthday [month] [day]"
+            )
+
+            return
+
+        month, day = None, None
+
+        if not args[0].isnumeric() or (month := int(args[0])) > 12:
+            await ctx.send(f"Does {args[0]} looks like a month number to you? ;-;")
+            return
+
+        if not args[1].isnumeric() or (day := int(args[1])) > 31:
+            await ctx.send(f"Does {args[1]} looks like a day of a month to you? ;-;")
+            return
+
+        await self.repo.set_birthdate(ctx.author.id, month, day)
+        await ctx.send(
+            "Awesome!\n" + 
+            "We will remember you birthday\n" +
+            "UmU"
+        )
+    
+    @commands.command(name="birthday-setup")
+    async def birthday_setup(self, ctx: commands.Context, *args):
+        """
+        Set-up birthday calendar for server!
+        """
+
+        if len(args) != 2:
+            await ctx.send(
+                "Invalid arguments ;-;\n" +
+                "**Usage: " +
+                f"{self.repo.get_prefix(ctx.guild.id)}**" +
+                "birthday-setup [channel for calendar] [channel for greets]"
+            )
+
+            return
+
+        if not util.isOwner(ctx):
+            await ctx.send("You don't have permission to issue this command. ;-;")
+            return
+
+        class NotFoundError(Exception): pass
+
+        async def find_channel_or_raise(toFind):
+            result = discord.utils.find(
+                lambda channel: channel.mention == toFind,
+                ctx.guild.channels
+            )
+
+            if result == None:
+                await ctx.send(f"Can't find channel: {toFind} ;-;")
+                raise NotFoundError()
+            return result
+
+        try:
+            calendar_channel = await find_channel_or_raise(args[0])
+            greet_channel = await find_channel_or_raise(args[1])
+
+            await self.repo.set_birthday_channels(
+                ctx.guild.id,
+                calendar_channel.id,
+                greet_channel.id
+            )
+
+            await ctx.send(
+                "Awesome!\n" +
+                "I've set it up as follows:\n" +
+                f"**Bithday calendar at:** {calendar_channel.mention}\n" +
+                f"**Greetings at:** {greet_channel.mention}\n" +
+                ":3"
+            )
+
+        except NotFoundError:
+            return
+
+    async def greet_birthday(self, channel, member):
+        await channel.send(f"Happy birthday {member.mention}!")
+
+    async def birthday_ticker(self, bot: commands.Bot):
+        while True:
+
+            if await self.repo.has_greeted_today():
+                print("Sleeping for long time")
+                await asyncio.sleep(15)
+                continue
+
+            birthdays = list(await self.repo.get_birthday_kids())
+
+            if birthdays != None:
+                for guild in bot.guilds:
+                    if (channel_ids := await self.repo.get_birthday_channels(guild.id)) != None:
+                        channel = guild.get_channel(channel_ids[1])
+
+                        for kid_id in birthdays:
+                            if kid_id in map(lambda member: member.id, guild.members):
+                                await self.greet_birthday(channel, guild.get_member(kid_id))
+                                
+                    else: print(f"Birthday channels not setup for guild: '{guild.name}' id: {guild.id}")
+
+                await self.repo.update_greet_completion_date()
+                print("Birthdays concluded.")
+
+            else:
+                print("No birthdays today.")
+                await self.repo.update_greet_completion_date()
+
+            await asyncio.sleep(5)

--- a/equibot/commandcogs/birthdays.py
+++ b/equibot/commandcogs/birthdays.py
@@ -1,9 +1,12 @@
 from discord.ext import commands
 import discord
 import asyncio
+import calendar
 
 from .. import util
 from .. import repository
+
+from .calendarbuider import CalendarBuilder
 
 class Birthdays(commands.Cog):
 
@@ -25,18 +28,91 @@ class Birthdays(commands.Cog):
             await ctx.send(f"Does {args[0]} looks like a month number to you? ;-;")
             return
 
-        if not args[1].isnumeric() or (day := int(args[1])) > 31:
-            await ctx.send(f"Does {args[1]} looks like a day of a month to you? ;-;")
+        if not args[1].isnumeric():
+            await ctx.send(f"Does {args[1]} looks like a number to you? ;-;")
+            return
+
+        month_limit = calendar.monthrange(0, month)[1]
+        if (day := int(args[1])) > month_limit:
+            await ctx.send(
+                f"{calendar.month_name[month]} has only {month_limit} days ;-;"
+            )
+
             return
 
         await self.repo.set_birthdate(ctx.author.id, month, day)
+
         await ctx.send(
             "Awesome!\n" + 
             "We will remember you birthday\n" +
             "UmU"
         )
-    
-    @commands.command(name="birthday-setup")
+
+        if not await self.update_calendar(ctx.guild):
+            await ctx.send(
+                "Note: This Server has not registered the channels " +
+                "to be used for greets and calendar, or one or more of " +
+                "calendar messages were deleted.\n" +
+                "Owner must run birthday-setup command for calendar to work"
+            )
+
+    async def update_calendar(self, guild: discord.Guild):
+        """
+        Updates the calendar messages.
+        Returns False if calendar channel was not registered or not found.
+        """
+
+        builder_map = dict(
+            map(
+                lambda b: (b.month, b),
+                [CalendarBuilder(month) for month in range(1, 13)]
+            )
+        )
+
+        for member in guild.members:
+            if (bd := await self.repo.get_user_birthdate(member.id)) == None:
+                continue
+
+            builder_map[bd[0]].add(member.mention, bd[1])
+
+        #Check if we know about which channel to post calendar.
+        channels = (await self.repo.get_birthday_channels(guild.id))
+        
+        if channels == None:
+            return False
+
+        calendar_channel_id = channels[0]
+
+        channel = guild.get_channel(calendar_channel_id)
+        if channel == None:
+            return False
+
+        #Check if calendar messages were created
+        #Create if not.
+        #id at 0 is for January, 1 for February and so on.
+
+        ids = await self.repo.get_calendar_message_ids(guild.id)
+        if ids == None: #Send new messages.
+            ids = []
+            for month in range(1, 13):
+                msg = await channel.send(str(builder_map[month]))
+                ids.append(msg.id)
+
+            #Store these in db for future use.
+            await self.repo.update_calendar_message_ids(guild.id, ids)
+
+        else: #Edit exsiting messages
+            for month in range(1, 13):
+                message_id = ids[month - 1]
+                msg = await channel.fetch_message(message_id)
+                if msg == None:
+                    return False #Don't go any further.
+
+                await msg.edit(content=builder_map[month])
+
+        return True
+
+    @commands.command(name="birthdaysetup", usage='birthdaysetup [channel for calendar] [channel for greets]')
     async def birthday_setup(self, ctx: commands.Context, *args):
         """
         Set-up birthday calendar for server!
@@ -53,12 +129,17 @@ class Birthdays(commands.Cog):
 
         if calendar_channel == None or greet_channel == None:
             return
+        
+        await ctx.message.add_reaction('👍🏼')
 
         await self.repo.set_birthday_channels(
             ctx.guild.id,
             calendar_channel.id,
             greet_channel.id
         )
+
+        await self.repo.clear_calendar_message_ids(ctx.guild.id)
+        await self.update_calendar(ctx.guild)
 
         await ctx.send(
             "Awesome!\n" +
@@ -79,7 +160,7 @@ class Birthdays(commands.Cog):
                 await asyncio.sleep(15)
                 continue
 
-            birthdays = list(await self.repo.get_birthday_kids())
+            birthdays = await self.repo.get_birthday_kids()
 
             if birthdays != None:
                 for guild in bot.guilds:

--- a/equibot/commandcogs/calendarbuider.py
+++ b/equibot/commandcogs/calendarbuider.py
@@ -1,0 +1,49 @@
+import calendar
+
+class CalendarBuilder:
+    """
+    Class for constructing calendar messages.
+    """
+
+    def __init__(self, month):
+        self.month = month
+        
+        self.name = calendar.month_name[month]
+        self.monthrange = calendar.monthrange(0, month)[1]
+        self.birthdays = dict(
+            map(
+                lambda n: (n, []),
+                range(1, self.monthrange + 1)
+            )
+        )
+
+    def add(self, person, day):
+        """
+        Add a person's birthday to this month.
+        """
+        self.birthdays[day].append(person)
+
+    def __str__(self):
+        """
+        Builds and returns the message text.
+        """
+
+        header = f'**{self.name}**'.rjust(20) + '\n'
+        header += '♡∞:｡.｡　　｡.｡:∞♡'.rjust(20) + '\n\n'
+
+        body = ''
+
+        for day in range(1, self.monthrange + 1):
+
+            day_str = str(day).ljust(2)
+
+            if len(self.birthdays[day]) == 0:
+                body += f'{day_str} 『 '.ljust(30) + ' 』\n'
+                continue
+            
+            chunk = ' '.join(self.birthdays[day])
+            body += f'{day_str} 『 {chunk}'.ljust(30) + ' 』\n'
+
+        footer = '♡∞:｡.｡　　｡.｡:∞♡'.rjust(20)
+
+        return header + body + footer

--- a/equibot/repository.py
+++ b/equibot/repository.py
@@ -138,6 +138,13 @@ class Repository:
         """
         await self.sql.set_user_birthdate(user_id, month, day)
 
+    async def get_user_birthdate(self, user_id):
+        """
+        Returns the birthdate tuple of the user if set using
+        `set_birthdate`, returns None otherwise.
+        """
+        return await self.sql.get_user_birthdate(user_id)
+
     async def has_greeted_today(self):
         """
         Returns true if bot has completed greetings for today.
@@ -153,3 +160,28 @@ class Repository:
 
         date = datetime.datetime.utcnow()
         await self.sql.update_bithday_completion_date(date.month, date.day)
+
+    async def update_calendar_message_ids(self, guild_id, ids):
+        """
+        Updates/inserts the ids of messages to be used for birthday calendar.
+        Each month has it's own message.
+        `ids` should be an iterable of message ids, starting from January to December.
+        """
+
+        await self.sql.update_calendar_message_ids(guild_id, ids)
+
+    async def clear_calendar_message_ids(self, guild_id):
+        """
+        Deletes calendar message id entries for the guild.
+        To be called when birthday-setup command is issued.
+        """
+
+        await self.sql.clear_calendar_message_ids(guild_id)
+
+    async def get_calendar_message_ids(self, guild_id):
+        """
+        Returns the tuple of message ids previously set through `update_calendar_message_ids()`
+        Returns None if never set.
+        """
+
+        return await self.sql.get_calendar_message_ids(guild_id)

--- a/equibot/repository.py
+++ b/equibot/repository.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 
 from . import sqlhelper
 from . import constants
@@ -107,3 +108,48 @@ class Repository:
         """
 
         await self.sql.set_afk_status(guild_id, user_id, reason)
+
+    #Birthday related
+    async def set_birthday_channels(self, guild_id, calendar_channel, greet_channel):
+        """
+        Sets the channels to use for birthday stuff.
+        """
+        await self.sql.set_birthday_channels(guild_id, calendar_channel, greet_channel)
+
+    async def get_birthday_channels(self, guild_id):
+        """
+        Returns the tuple of channels to be used for birthday stuff.
+        Returns None if entry does not exists.
+        """
+        return await self.sql.get_birthday_channels(guild_id)
+
+    async def get_birthday_kids(self):
+        """
+        Returns a map of user ids which have their birthday today.
+        Returns n
+        """
+
+        date = datetime.datetime.utcnow()
+        return await self.sql.get_birthday_kids(date.month, date.day)
+
+    async def set_birthdate(self, user_id, month, day):
+        """
+        Updates your birthdate. 
+        """
+        await self.sql.set_user_birthdate(user_id, month, day)
+
+    async def has_greeted_today(self):
+        """
+        Returns true if bot has completed greetings for today.
+        """
+        date = datetime.datetime.utcnow()
+        return await self.sql.get_birthday_completion_date() == (date.month, date.day)
+
+    async def update_greet_completion_date(self):
+        """
+        Updates the completion date in SQL, declaring that we have
+        greeted all the birthdays today
+        """
+
+        date = datetime.datetime.utcnow()
+        await self.sql.update_bithday_completion_date(date.month, date.day)

--- a/equibot/repository.py
+++ b/equibot/repository.py
@@ -125,7 +125,7 @@ class Repository:
 
     async def get_birthday_kids(self):
         """
-        Returns a map of user ids which have their birthday today.
+        Returns a list of user ids which have their birthday today.
         Returns n
         """
 

--- a/equibot/sqlhelper.py
+++ b/equibot/sqlhelper.py
@@ -141,6 +141,63 @@ sql_get_bithday_completion_date = """
     WHERE id = 0
     """
 
+#Message IDs for calendar messages.
+sql_create_calendar_messages_table = """
+    CREATE TABLE IF NOT EXISTS calendar_messages(
+        guild_id    INTEGER PRIMARY KEY,
+        january     INTEGER NOT NULL,
+        february    INTEGER NOT NULL,
+        march       INTEGER NOT NULL,
+        april       INTEGER NOT NULL,
+        may         INTEGER NOT NULL,
+        june        INTEGER NOT NULL,
+        july        INTEGER NOT NULL,
+        august      INTEGER NOT NULL,
+        september   INTEGER NOT NULL,
+        october     INTEGER NOT NULL,
+        november    INTEGER NOT NULL,
+        december    INTEGER NOT NULL
+    )
+    """
+
+sql_update_calendar_message_ids = """
+    INSERT INTO calendar_messages(
+        guild_id, january, february, march,
+        april, may, june, july, august,
+        september, october, november, december
+    )
+    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+
+    ON CONFLICT(guild_id)
+    DO UPDATE SET
+        january   =  excluded.january  ,
+        february  =  excluded.february ,
+        march     =  excluded.march    ,
+        april     =  excluded.april    ,
+        may       =  excluded.may      ,
+        june      =  excluded.june     ,
+        july      =  excluded.july     ,
+        august    =  excluded.august   ,
+        september =  excluded.september,
+        october   =  excluded.october  ,
+        november  =  excluded.november ,
+        december  =  excluded.december 
+    """
+
+sql_clear_calendar_message_ids = """
+    DELETE FROM calendar_messages
+    WHERE guild_id = ?
+    """
+
+sql_get_calendar_messages = """
+    SELECT january, february, march,
+        april, may, june, july, august,
+        september, october, november, december
+
+    FROM calendar_messages
+    WHERE guild_id = ?
+    """
+
 class SqlHelper:
     """
     Class used for running SQL queries.
@@ -176,6 +233,7 @@ class SqlHelper:
             cursor.execute(sql_create_birthday_completion_table)
             cursor.execute(sql_create_birthday_completion_row)
             conn.commit()
+            cursor.execute(sql_create_calendar_messages_table)
         except sqlite3.Error as e:
             print(e, file=sys.stderr)
         finally:
@@ -332,7 +390,7 @@ class SqlHelper:
             if result == None:
                 return None
             else:
-                return result[0]
+                return result
         except sqlite3.Error as e:
             print(e, file=sys.stderr)
         finally:
@@ -382,6 +440,41 @@ class SqlHelper:
             conn = self.connect_db()
             cursor = conn.cursor()
             cursor.execute(sql_get_bithday_completion_date)
+
+            return cursor.fetchone()
+
+        except sqlite3.Error as e:
+            print(e, file=sys.stderr)
+        finally:
+            if conn: conn.close()
+
+    async def update_calendar_message_ids(self, guild_id, ids):
+        try:
+            conn = self.connect_db()
+            cursor = conn.cursor()
+            cursor.execute(sql_update_calendar_message_ids, (guild_id, *ids))
+            conn.commit()
+        except sqlite3.Error as e:
+            print(e, file=sys.stderr)
+        finally:
+            if conn: conn.close()
+
+    async def clear_calendar_message_ids(self, guild_id):
+        try:
+            conn = self.connect_db()
+            cursor = conn.cursor()
+            cursor.execute(sql_clear_calendar_message_ids, (guild_id,))
+            conn.commit()
+        except sqlite3.Error as e:
+            print(e, file=sys.stderr)
+        finally:
+            if conn: conn.close()
+
+    async def get_calendar_message_ids(self, guild_id):
+        try:
+            conn = self.connect_db()
+            cursor = conn.cursor()
+            cursor.execute(sql_get_calendar_messages, (guild_id,))
 
             return cursor.fetchone()
 

--- a/equibot/tests/test_birthday.py
+++ b/equibot/tests/test_birthday.py
@@ -1,0 +1,46 @@
+import pytest
+import datetime
+
+from .fixtures import delete_db
+from ..repository import Repository
+
+GUILD_ID = 55
+CAL_CHAN = 21
+GREET_CHAN = 22
+USER1 = 77
+USER2 = 78
+
+@pytest.mark.asyncio()
+async def test_birthdays():
+    repo = await Repository.create('_test.db')
+
+    assert await repo.get_birthday_channels(GUILD_ID) == None
+    assert await repo.get_birthday_kids() == None
+
+    await repo.set_birthday_channels(GUILD_ID, CAL_CHAN, GREET_CHAN)
+    chans = await repo.get_birthday_channels(GUILD_ID)
+    assert chans[0] == CAL_CHAN
+    assert chans[1] == GREET_CHAN
+
+    date = datetime.datetime.utcnow()
+    await repo.set_birthdate(USER1, date.month, date.day)
+
+    assert len(list(await repo.get_birthday_kids())) == 1
+    assert list((await repo.get_birthday_kids()))[0] == USER1
+
+    await repo.set_birthdate(USER2, date.month, date.day)
+    assert USER2 in (await repo.get_birthday_kids())
+    assert USER1 in (await repo.get_birthday_kids())
+
+@pytest.mark.asyncio()
+async def test_birthday_completion():
+    repo = await Repository.create('_test.db')
+
+    assert not await repo.has_greeted_today()
+    await repo.update_greet_completion_date()
+
+    assert await repo.has_greeted_today()
+
+    del repo
+    repo = await Repository.create('_test.db')
+    assert await repo.has_greeted_today()

--- a/equibot/tests/test_birthday.py
+++ b/equibot/tests/test_birthday.py
@@ -44,3 +44,18 @@ async def test_birthday_completion():
     del repo
     repo = await Repository.create('_test.db')
     assert await repo.has_greeted_today()
+
+@pytest.mark.asyncio()
+async def test_birthday_calendar():
+
+    repo = await Repository.create('_test.db')
+
+    assert await repo.get_calendar_message_ids(GUILD_ID) == None
+
+    ids = (5, 6, 7, 5, 6, 7, 3, 66, 700, 900, 55, 7)
+    await repo.update_calendar_message_ids(GUILD_ID, ids)
+    assert await repo.get_calendar_message_ids(GUILD_ID) == ids
+
+    ids = ids[::-1]
+    await repo.update_calendar_message_ids(GUILD_ID, ids)
+    assert await repo.get_calendar_message_ids(GUILD_ID) == ids

--- a/equibot/util.py
+++ b/equibot/util.py
@@ -1,3 +1,6 @@
+import discord
+
+
 """
 Utility funtions
 """
@@ -44,3 +47,20 @@ async def ensure_args(ctx, count, args):
         return False
 
     return True
+
+async def find_channel_by_mention(ctx, toFind):
+    """
+    Tries to find the channel by mention.
+    Sends error if fails, returning None or returns the found channel otherwise
+    """
+    channel = discord.utils.find(
+        lambda channel: channel.mention == toFind,
+        ctx.guild.channels
+    )
+
+    if channel == None:
+        await ctx.send(f"Can't find channel: {toFind} ;-;")
+
+    return channel
+
+    

--- a/equibot/util.py
+++ b/equibot/util.py
@@ -13,3 +13,9 @@ async def isModeratorOrOwner(ctx, repo):
         if mod in map(lambda role: role.id, ctx.author.roles):
             return True
     return False
+
+def isOwner(ctx):
+    """
+    Returns true of sender is the server owner.
+    """
+    return ctx.author == ctx.guild.owner


### PR DESCRIPTION
# Description
The `~bithday` command allows users to declare their birthdays to the bot. Bot will greet the users when the day arrives. Greetings are issued only if moderators have set which channel to greet on using `~birthday-setup`.

### Calendar
A channel is selected when issuing `~birthday-setup` to which formatted messages are posted which look like calendar and mark the birthdays of members of the guild.

# TODO
- [x] Implement calendar