### PR TITLE
Log commands via print

### DIFF
--- a/equibot/cogs/birthdays.py
+++ b/equibot/cogs/birthdays.py
@@ -17,6 +17,8 @@ class Birthdays(commands.Cog):
         Add your name to birthday calendar!
         """
 
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
+
         if not await util.ensure_args(ctx, 2, args):
             return
 
@@ -118,6 +120,8 @@ class Birthdays(commands.Cog):
         Set-up birthday calendar for server!
         """
 
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
+
         if not await util.ensureOwner(ctx):
             return
 
@@ -195,6 +199,8 @@ class Birthdays(commands.Cog):
         """
         Set a role to ping when there's somebody's birthday.
         """
+
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
 
         if not await util.ensureOwner(ctx):
             return

--- a/equibot/cogs/general.py
+++ b/equibot/cogs/general.py
@@ -18,6 +18,8 @@ class General(commands.Cog):
         Changes the prefix for the bot in your server.
         """
 
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
+
         if not await util.ensure_args(ctx, 1, args):
             return
 
@@ -36,6 +38,8 @@ class General(commands.Cog):
         Set your AFK status.
         People who mention you will get notice of you being AFK.
         """
+
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
 
         reason =  ' '.join(reason)
         if reason.isspace() or reason == '':

--- a/equibot/cogs/moderation.py
+++ b/equibot/cogs/moderation.py
@@ -30,6 +30,8 @@ class Moderation(commands.Cog):
         This allows people with this role to issue moderation commands.
         """
 
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
+
         if ctx.author != ctx.guild.owner:
             await ctx.send('Only owner can use this command. ;-;')
             return
@@ -55,6 +57,9 @@ class Moderation(commands.Cog):
 
     @modrole.command(name='remove', usage='modrole remove [role name | role mention]')
     async def modrole_remove(self, ctx: commands.Context, *args):
+
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
+
         if ctx.author != ctx.guild.owner:
             await ctx.send('Only owner can use this command. ;-;')
             return
@@ -83,6 +88,8 @@ class Moderation(commands.Cog):
         """
         Deletes a specified number of messages from the channel.
         """
+
+        print(f'Command {ctx.command.name} from guild {ctx.guild.name}')
 
         if not await util.ensureModeratorOrOwner(ctx, self.repo):
             return


### PR DESCRIPTION
Log all the commands via `print`. Helps in identifying source of exceptions thrown in production.